### PR TITLE
version number visable

### DIFF
--- a/Mexer_site/Mexer/views/misc.py
+++ b/Mexer_site/Mexer/views/misc.py
@@ -17,6 +17,7 @@ from django.shortcuts import render
 from Mexer.models import Dataset, matname
 from Mexer.views.error_pages import *
 from django.http import HttpResponse
+from Mexer_meta.settings import SITE_VERSION
 
 
 @time_view
@@ -29,7 +30,7 @@ def index(request):
 def about(request):
     ''' Render the 'About' page.'''
     LOGGER.info("About page visted.")
-    return render(request, 'about.html')
+    return render(request, 'about.html', context={"site_version":SITE_VERSION})
 
 def plot_stage(request):
     ''' Give the plot stage, for plotting in a separate window '''

--- a/Mexer_site/Mexer/views/visualizer.py
+++ b/Mexer_site/Mexer/views/visualizer.py
@@ -27,6 +27,7 @@ from utils.matrix import get_matrix, get_ruvy_matrix, visualize_matrix
 from plotly.offline import plot
 from utils.history import update_user_history
 from altair.utils.data import MaxRowsError # for catching with matrices are too big
+from Mexer_meta.settings import SITE_VERSION
 
 @login_required(login_url="/login")
 @time_view
@@ -113,7 +114,9 @@ def visualizer(request):
         "industry_aggregations":industry_aggregations,
         "default_industry_aggregation":industry_aggregations[0],
 
-        "iea_user":iea_user
+        "iea_user":iea_user,
+
+        "site_version":SITE_VERSION, # version of the site to be displayed to users 
         }
 
     return render(request, "visualizer.html", context)

--- a/Mexer_site/Mexer_meta/settings.py
+++ b/Mexer_site/Mexer_meta/settings.py
@@ -24,6 +24,8 @@ SECRET_KEY = environ["django_secret_key"]
 # Example: python3 manage.py debug
 DEBUG = False
 
+SITE_VERSION = "4.1.3" # the version number of Mexer to be displayed on the about and visualizer page
+
 ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
 
 SESSION_COOKIE_SECURE = True

--- a/Mexer_site/templates/about.html
+++ b/Mexer_site/templates/about.html
@@ -33,6 +33,7 @@
   </svg>
 
   <div class="about-content">
+    <p>Mexer Version {{site_version}}</p>
     <h1>About Us</h1>
     <p>
       Welcome to Mexer. Our mission is to empower researchers to better

--- a/Mexer_site/templates/visualizer.html
+++ b/Mexer_site/templates/visualizer.html
@@ -552,6 +552,7 @@
     </div>
     </form>
     <div class="arrow-section" onclick='document.getElementById("plot-section").scrollIntoView();'>
+        <h2>Mexer Version {{site_version}}</h2>
         <h3> Plotting Area Below </h3>
         <div class="arrow">
             <span></span>


### PR DESCRIPTION
A version number of the site now appears at the top of the About page and just to the side of the query box on the Visualizer page.

This number is set in `Mexer_meta/settings.py` as it is a meta-level setting.