### PR TITLE
Use Django's native static file system

### DIFF
--- a/Mexer_site/Mexer/urls.py
+++ b/Mexer_site/Mexer/urls.py
@@ -1,4 +1,6 @@
 from django.urls import path, re_path
+from django.conf import settings
+from django.conf.urls.static import static
 import Mexer.views.history as history_views
 import Mexer.views.misc as misc_views
 import Mexer.views.user_accounts as accounts_views
@@ -32,13 +34,18 @@ __urlpatterns = [
     path('terms_and_conditions/', misc_views.terms_and_conditions, name='terms_and_conditions'),
     path('data-info/', misc_views.data_info, name="data-info"),
     path('matrix-info/', misc_views.matrix_info, name="matrix-info"),
-    re_path(r"static/(.*/[^(\.)]*\..*)", misc_views.handle_static),
     path("plot-stage/", misc_views.plot_stage),
 ]
 
 # append testing routes
 if settings.DEBUG:
     __urlpatterns.append(re_path(r"test_render/(.*)", misc_views.__test_render_page))
+
+    # Static files should only be directly accessible when debugging.
+    __urlpatterns.append(static(
+        settings.STATIC_URL,
+        document_root=settings.STATIC_BASE,
+    ))
 
 # apply, "urlpatterns" is what Django will be given
 urlpatterns = __urlpatterns

--- a/Mexer_site/Mexer/urls.py
+++ b/Mexer_site/Mexer/urls.py
@@ -41,11 +41,11 @@ __urlpatterns = [
 if settings.DEBUG:
     __urlpatterns.append(re_path(r"test_render/(.*)", misc_views.__test_render_page))
 
-    # Static files should only be directly accessible when debugging.
-    __urlpatterns += static(
-        settings.STATIC_URL,
-        document_root=settings.STATICFILES_DIRS[0],
-    )
+# TODO: configure a static route in Nginx and hide this in production.
+__urlpatterns += static(
+    settings.STATIC_URL,
+    document_root=settings.STATICFILES_DIRS[0],
+)
 
 # apply, "urlpatterns" is what Django will be given
 urlpatterns = __urlpatterns

--- a/Mexer_site/Mexer/urls.py
+++ b/Mexer_site/Mexer/urls.py
@@ -42,10 +42,10 @@ if settings.DEBUG:
     __urlpatterns.append(re_path(r"test_render/(.*)", misc_views.__test_render_page))
 
     # Static files should only be directly accessible when debugging.
-    __urlpatterns.append(static(
+    __urlpatterns += static(
         settings.STATIC_URL,
-        document_root=settings.STATIC_BASE,
-    ))
+        document_root=settings.STATICFILES_DIRS[0],
+    )
 
 # apply, "urlpatterns" is what Django will be given
 urlpatterns = __urlpatterns

--- a/Mexer_site/Mexer/views/misc.py
+++ b/Mexer_site/Mexer/views/misc.py
@@ -56,46 +56,6 @@ def matrix_info(request):
     # Retrieve all Dataset objects from the database
     matricies = matname.objects.all()
     return render(request, 'matrix_info.html', context = {"matricies":matricies})
-
-def handle_static(request, filepath: str):
-    """Serve CSS static files directly from a specified directory.
-
-    This function reads a CSS file from a static files directory
-    and serves it as an HTTP response with the appropriate content type.
-
-    Inputs:
-        request: The HTTP request object (not used in this function, but typically included for view functions)
-        filepath: The path to the CSS file relative to the static files directory
-
-    Outputs:
-        HttpResponse containing the contents of the CSS file
-    """
-    # example filepath: css/toolbar.css OR admin/css/toolbar.css
-    
-    # the type of static file to serve is used in the match case
-    # so that the correct mime type is attached
-    # other than that, the whole filepath asked for (besides static/) is used to find the file
-    file_type = filepath.split("/")[0] if filepath.split("/")[0] != "admin" else filepath.split("/")[1]
-    match(file_type):
-        case "css":
-            mime_type = "text/css"
-        
-        case "images" | "img":
-            # filepath.split(".")[-1] is the last part of the file, i.e. the handle like jpeg, png, etc.
-            # if the handle is svg, the mime must be image/svg+xml
-            mime_type = f"image/{filepath.split('.')[-1] if not filepath.endswith('svg') else 'svg+xml'}"
-            
-        case "js":
-            mime_type = "text/javascript"
-        
-        case _:
-            return error_404(request, f"Couldn't figure out content type of {filepath}")
-    
-    try:
-        with open(f"{settings.STATIC_BASE}/{filepath}", "rb") as f:
-                return HttpResponse(f.read(), headers = {"Content-Type": mime_type})
-    except Exception as e:
-        return error_404(request, e)
     
 def __test_render_page(request, template_name: str):
     """Render a template that matches the path name from the request."""

--- a/Mexer_site/Mexer_meta/settings.py
+++ b/Mexer_site/Mexer_meta/settings.py
@@ -158,15 +158,11 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# NOT used in the Django way...
-# see Mexer/views/misc.py for how statics are handled
-STATIC_URL = 'static/'
+STATIC_URL = '/static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 STATICFILES_DIRS = [
     BASE_DIR / "static",
-    BASE_DIR / "static/css",
-    BASE_DIR / "static/js",
 ]
-STATIC_BASE = BASE_DIR / "static"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field

--- a/Mexer_site/templates/about.html
+++ b/Mexer_site/templates/about.html
@@ -7,7 +7,7 @@
 {% block extra_head %}
   <!-- components -->
   {% include "snippets/card.html" %} <!-- include template html -->
-  <script src={% static "js/components/card.js" %} defer></script> <!-- include web component script -->
+  <script src="{% static 'js/components/card.js' %"} defer></script> <!-- include web component script -->
   <!-- end components -->
 {% endblock %}
 

--- a/Mexer_site/templates/about.html
+++ b/Mexer_site/templates/about.html
@@ -7,7 +7,7 @@
 {% block extra_head %}
   <!-- components -->
   {% include "snippets/card.html" %} <!-- include template html -->
-  <script src="{% static 'js/components/card.js' %"} defer></script> <!-- include web component script -->
+  <script src="{% static 'js/components/card.js' %}" defer></script> <!-- include web component script -->
   <!-- end components -->
 {% endblock %}
 

--- a/Mexer_site/templates/bases/announcement_page_base.html
+++ b/Mexer_site/templates/bases/announcement_page_base.html
@@ -18,7 +18,7 @@ Blocks:
 {% block extra_head %}
   <!-- components -->
   {% include "snippets/card.html" %} <!-- include template html -->
-  <script src={% static "js/components/card.js" %} defer></script> <!-- include web component script -->
+  <script src="{% static 'js/components/card.js' %}" defer></script> <!-- include web component script -->
   <!-- end components -->
 
   <!-- for use with para-bg elements below -->

--- a/Mexer_site/templates/bases/authentication_page_base.html
+++ b/Mexer_site/templates/bases/authentication_page_base.html
@@ -19,9 +19,9 @@ Blocks:
 {% block extra_head %}
   <!-- components -->
   {% include "snippets/card.html" %} <!-- include template html -->
-  <script src={% static "js/components/card.js" %} defer></script> <!-- include web component script -->
+  <script src="{% static 'js/components/card.js' %}" defer></script> <!-- include web component script -->
   {% include "snippets/form-input.html" %}
-  <script src={% static "js/components/formInput.js" %} defer></script>
+  <script src="{% static 'js/components/formInput.js' %}" defer></script>
   <!-- end components -->
 
   <!-- for use with para-bg elements below -->

--- a/Mexer_site/templates/data_info.html
+++ b/Mexer_site/templates/data_info.html
@@ -7,7 +7,7 @@
 {% block extra_head %}
     <!-- components -->
     {% include "snippets/card.html" %} <!-- include template html -->
-    <script src={% static "js/components/card.js" %} defer></script> <!-- include web component script -->
+    <script src="{% static 'js/components/card.js' %}" defer></script> <!-- include web component script -->
     <!-- end components -->
 {% endblock %}
 {% block content %}

--- a/Mexer_site/templates/error_pages/400.html
+++ b/Mexer_site/templates/error_pages/400.html
@@ -1,8 +1,9 @@
+{% load static %}
 <head>
     <title>About Mexer</title>
-    <link rel="stylesheet" href="../static/css/toolbar.css" type="text/css" />
-    <link rel="stylesheet" href="../static/css/error-page.css" type="text/css" />
-    <link rel="icon" type="image/x-icon" href="../static/images/favicon.png" />
+    <link rel="stylesheet" href="{% static 'css/toolbar.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% static 'css/error-page.css' %}" type="text/css" />
+    <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}" />
   </head>
   
   <body>

--- a/Mexer_site/templates/error_pages/403.html
+++ b/Mexer_site/templates/error_pages/403.html
@@ -1,8 +1,9 @@
+{% load static %}
 <head>
     <title>About Mexer</title>
-    <link rel="stylesheet" href="../static/css/toolbar.css" type="text/css" />
-    <link rel="stylesheet" href="../static/css/error-page.css" type="text/css" />
-    <link rel="icon" type="image/x-icon" href="../static/images/favicon.png" />
+    <link rel="stylesheet" href="{% static 'css/toolbar.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% static 'css/error-page.css' %}" type="text/css" />
+    <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}" />
   </head>
   
   <body>

--- a/Mexer_site/templates/error_pages/404.html
+++ b/Mexer_site/templates/error_pages/404.html
@@ -1,8 +1,9 @@
+{% load static %}
 <head>
     <title>About Mexer</title>
-    <link rel="stylesheet" href="../static/css/toolbar.css" type="text/css" />
-    <link rel="stylesheet" href="../static/css/error-page.css" type="text/css" />
-    <link rel="icon" type="image/x-icon" href="../static/images/favicon.png" />
+    <link rel="stylesheet" href="{% static 'css/toolbar.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% static 'css/error-page.css' %}" type="text/css" />
+    <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}" />
   </head>
   
   <body>

--- a/Mexer_site/templates/error_pages/500.html
+++ b/Mexer_site/templates/error_pages/500.html
@@ -1,8 +1,9 @@
+{% load static %}
 <head>
     <title>About Mexer</title>
-    <link rel="stylesheet" href="../static/css/toolbar.css" type="text/css" />
-    <link rel="stylesheet" href="../static/css/error-page.css" type="text/css" />
-    <link rel="icon" type="image/x-icon" href="../static/images/favicon.png" />
+    <link rel="stylesheet" href="{% static 'css/toolbar.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% static 'css/error-page.css' %}" type="text/css" />
+    <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}" />
   </head>
   
   <body>

--- a/Mexer_site/templates/error_pages/csrf_error.html
+++ b/Mexer_site/templates/error_pages/csrf_error.html
@@ -1,8 +1,9 @@
+{% load static %}
 <head>
     <title>About Mexer</title>
-    <link rel="stylesheet" href="../static/css/toolbar.css" type="text/css" />
-    <link rel="stylesheet" href="../static/css/error-page.css" type="text/css" />
-    <link rel="icon" type="image/x-icon" href="../static/images/favicon.png" />
+    <link rel="stylesheet" href="{% static 'css/toolbar.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% static 'css/error-page.css' %}" type="text/css" />
+    <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}" />
   </head>
   
   <body>

--- a/Mexer_site/templates/index.html
+++ b/Mexer_site/templates/index.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="{% static 'css/bg-waves.css' %}" type="text/css" />
   <!-- components -->
   {% include "snippets/card.html" %} <!-- include template html -->
-  <script src={% static "js/components/card.js" %} defer></script> <!-- include web component script -->
+  <script src="{% static 'js/components/card.js' %}" defer></script> <!-- include web component script -->
   <!-- end components -->
 {% endblock %}
 

--- a/Mexer_site/templates/matrix_info.html
+++ b/Mexer_site/templates/matrix_info.html
@@ -6,7 +6,7 @@
 {% block extra_head %}
     <!-- components -->
     {% include "snippets/card.html" %} <!-- include template html -->
-    <script src={% static "js/components/card.js" %} defer></script> <!-- include web component script -->
+    <script src="{% static 'js/components/card.js' %}" defer></script> <!-- include web component script -->
     <!-- end components -->
 {% endblock %}
 

--- a/Mexer_site/templates/plot_stage.html
+++ b/Mexer_site/templates/plot_stage.html
@@ -1,14 +1,15 @@
+{% load static %}
 <!DOCTYPE html>
 <html  lang="en">
 <head>
     <!-- External libraries -->
     <script src="https://cdn.plot.ly/plotly-latest.min.js" charset="utf-8"></script> <!-- Plotly -->
-    <link rel="stylesheet" href='../static/css/SanKEY_styles.css'> <!-- SanKEY css -->
-    <script type="module" src="../static/js/plotUtil.js"></script> <!-- type is module because we import SanKEY code -->
+    <link rel="stylesheet" href="{% static 'css/SanKEY_styles.css' %}"> <!-- SanKEY css -->
+    <script type="module" src="{% static 'js/plotUtil.js' %}"></script> <!-- type is module because we import SanKEY code -->
     <script src="https://cdn.jsdelivr.net/npm/vega@5.21.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-lite@4.17.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.17.0"></script>
-    <link rel="icon" type="image/x-icon" href="../static/images/favicon.png" />
+    <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}" />
 </head>
 
 <body>

--- a/Mexer_site/templates/terms_and_conditions.html
+++ b/Mexer_site/templates/terms_and_conditions.html
@@ -6,7 +6,7 @@
 {% block extra_head %}
   <!-- components -->
   {% include "snippets/card.html" %} <!-- include template html -->
-  <script src={% static "js/components/card.js" %} defer></script> <!-- include web component script -->
+  <script src="{% static 'js/components/card.js' %}" defer></script> <!-- include web component script -->
   <!-- end components -->
 {% endblock %}
 

--- a/Mexer_site/templates/visualizer.html
+++ b/Mexer_site/templates/visualizer.html
@@ -37,7 +37,7 @@
   <!-- External libraries -->
   <script src="https://unpkg.com/htmx.org@1.9.12"></script> <!-- HTMX -->
   <script src="https://cdn.plot.ly/plotly-latest.min.js" charset="utf-8"></script> <!-- Plotly -->
-  <link rel="stylesheet" href='../static/css/SanKEY_styles.css'> <!-- SanKEY css -->
+  <link rel="stylesheet" href="{% static 'css/SanKEY_styles.css' %"> <!-- SanKEY css -->
 
   <!-- External libraries: Vega -->
   <script src="https://cdn.jsdelivr.net/npm/vega@5.21.0"></script>
@@ -45,18 +45,18 @@
   <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.17.0"></script>
 
   <!-- Internal JS -->
-  <script src="../static/js/visualizer.js"></script>
+  <script src="{% static 'js/visualizer.js' %}"></script>
 
   <!-- Make the plot utility imports available throughout the window -->
   <script type="module">
-      import {downloadSankey, createSankey} from "../static/js/plotUtil.js";
+      import {downloadSankey, createSankey} from "{% static 'js/plotUtil.js' %}";
       window.downloadSankey = downloadSankey;
       window.createSankey = createSankey;
   </script>
 
   <!-- components -->
   {% include "snippets/card.html" %} <!-- include template html -->
-  <script src={% static "js/components/card.js" %} defer></script> <!-- include web component script -->
+  <script src="{% static 'js/components/card.js' %}" defer></script> <!-- include web component script -->
   <!-- end components -->
 
 {% endblock %}


### PR DESCRIPTION
Changes were already underway to migrate to Django's `{% static %}` tag from the custom `handle_static` function in `misc.py`. This pull request completes that migration. It also fixes what appear to be syntax errors in multiple places concerning existing usages of the `static` template tag.

While this is functioning locally, there are [additional details related to deployment](https://docs.djangoproject.com/en/5.2/howto/static-files/#deployment) that I'm unsure how to navigate, which is why I've requested review.