### PR TITLE
add docker compose profile for production

### DIFF
--- a/Mexer_site/Mexer_meta/settings.py
+++ b/Mexer_site/Mexer_meta/settings.py
@@ -124,7 +124,6 @@ DATABASES = {
             "application_name": "Mexer Site"
         }
     }
-
 }
 
 DATABASE_ROUTERS = ["Mexer.routers.LocalRouter" if IS_LOCAL else "Mexer.routers.DatabaseRouter"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   db:
+    profiles: [local]
     image: postgres:latest
     container_name: postgres
     restart: unless-stopped
@@ -20,6 +21,7 @@ services:
       retries: 20
 
   web:
+    profiles: [local]
     build:
       context: .
       dockerfile: dockerfile
@@ -30,6 +32,8 @@ services:
         condition: service_healthy
     env_file:
       - .env
+    environment:
+      local: "true"
     ports:
       - "8000:8000"
     volumes:
@@ -42,6 +46,27 @@ services:
       - command: ["python3", "manage.py", "migrate"]
       - command: ["python3", "manage.py", "load_test_data", "--dir", "/app/postgres/seeds"]
       - command: ["sh", "-c", "python3 manage.py createsuperuser --noinput --username \"$DJANGO_SUPERUSER_USERNAME\" --email \"$DJANGO_SUPERUSER_EMAIL\" || true"]
+
+  production:
+    profiles: [production]
+    build:
+      context: .
+      dockerfile: dockerfile
+    container_name: mexer_production
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      PGSERVICEFILE: /app/.pg_service.conf
+      PGPASSFILE: /app/.pgpass
+      local: "false"
+    ports:
+      - "8000:8000"
+    volumes:
+      - /usr/share/dict/words:/usr/share/dict/words:ro
+      - ./Mexer_site/general.log:/app/general.log:rw
+    command: ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
+
 volumes:
   postgres_data:
 

--- a/dockerfile
+++ b/dockerfile
@@ -8,7 +8,3 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Bring in all the source code
 COPY --chmod=0600 Mexer_site/ .
-
-# Set environment variables
-ENV PGSERVICEFILE=/app/.pg_service.conf
-ENV PGPASSFILE=/app/.pgpass


### PR DESCRIPTION
To run local

`sudo docker compose --profile local up -d`

To run production

`sudo docker compose --profile production up -d`

To set up for production:

1) Have the `.pgpass` and `.pg_service.conf` files in the continer's root directory (this is the same directory with `manage.py`)
2) Ensure both `.pgpass` and `.pg_service.conf` have access rights of `0600` by running `chmod 0600 .pgpass .pg_service.conf`

3) You can permanently remove the `local` option from your `.env` file. (the compose script now manages this)