### PR TITLE
Visualizer documentation upgrades

### DIFF
--- a/Mexer_site/Mexer/views/visualizer.py
+++ b/Mexer_site/Mexer/views/visualizer.py
@@ -4,14 +4,13 @@
 # The three main views are
 # The visualizer page itself - where users make queries and see plots
 # The plotting page - the page where, given a post request, plot html will be returned
-# The data page - the page where, given a post request, data in csv or excel (wip) will be returned
+# The data page - the page where, given a post request, data in csv or excel will be returned
 #
 # Authors:
 #       Kenny Howes - kmh67@calvin.edu
 #       Edom Maru - eam43@calvin.edu
 #####################
 import time
-from typing import Any  # for timestamp in data file name
 
 from altair.utils.data import MaxRowsError  # for catching with matrices are too big
 from django.conf import settings

--- a/Mexer_site/Mexer/views/visualizer.py
+++ b/Mexer_site/Mexer/views/visualizer.py
@@ -18,7 +18,19 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
-from Mexer.models import AggEtaPFU, EvizUser, Version
+from Mexer.models import (
+    AggEtaPFU,
+    AggLevel,
+    Country,
+    Dataset,
+    EnergyType,
+    EvizUser,
+    GrossNet,
+    LastStage,
+    Method,
+    Version,
+    matname,
+)
 from plotly.offline import plot
 from utils.data import (
     AGGETA_COLUMNS,
@@ -66,15 +78,16 @@ def visualizer(request):
         print(e)
         admin_user = False
 
-    # Fetch all available options for various parameters from the Translator
-    if admin_user:
-        datasets = Translator.get_all("datasets:admin")
-    else:
-        datasets = Translator.get_all("datasets:public")
+    # Temporary, do not use translator.
+    # TODO: Lookup rewrite should include
+    # descriptions as part of entries.
 
-    countries = Translator.get_all("country")
-    countries.sort()
-    versions = Translator.get_all("version")
+    if admin_user:
+        datasets = list(Dataset.objects.all())
+    else:
+        datasets = list(Dataset.objects.filter(Public=True))
+
+    versions = Version.objects.all()
     if admin_user:
         sandbox_versions = [
             settings.SANDBOX_PREFIX + ver
@@ -84,16 +97,22 @@ def visualizer(request):
         ]
     else:
         sandbox_versions = []
-    # methods = Translator.get_all('method')
-    methods = ["PCM"]  # override, we don't show all the options
-    energy_types = Translator.get_all("energytype")
-    # last_stages = Translator.get_all('laststage')
-    last_stages = ["Final", "Useful"]  # override, we don't show all the options
-    grossnets = Translator.get_all("grossnet")
-    product_aggregations = Translator.get_all("agglevel")
-    industry_aggregations = Translator.get_all("agglevel")
-    matnames = Translator.get_all("matname")
-    matnames.sort(key=len)  # sort matrix names by how long they are... seems reasonable
+
+    countries = list(Country.objects.all())
+    countries.sort(key=lambda country: country.FullName)
+
+    methods = list(method for method in Method.objects.all() if method.Method == "PCM")
+    energy_types = list(EnergyType.objects.all())
+    last_stages = list(
+        stage
+        for stage in LastStage.objects.all()
+        if stage.ECCStage in ("Final", "Useful")
+    )
+    grossnets = list(GrossNet.objects.all())
+    agglevels = list(AggLevel.objects.all())
+
+    matnames = list(matname.objects.all())
+    matnames.sort(key=lambda mat: mat.matname)
 
     # Prepare the context dictionary for the template
     context = {
@@ -106,19 +125,17 @@ def visualizer(request):
         "countries": countries,
         "default_country": "Ghana",
         "methods": methods,
-        "default_method": methods[0],
+        "default_method": methods[0].Method,
         "energy_types": energy_types,
-        "default_energy_type": energy_types[0],
+        "default_energy_type": energy_types[0].EnergyType,
         "last_stages": last_stages,
-        "default_last_stage": last_stages[0],
+        "default_last_stage": last_stages[0].ECCStage,
         "grossnets": grossnets,
-        "default_grossnet": grossnets[0],
+        "default_grossnet": grossnets[0].GrossNet,
         "matnames": matnames,
-        "default_matname": matnames[0],
-        "product_aggregations": product_aggregations,
-        "default_product_aggregation": product_aggregations[0],
-        "industry_aggregations": industry_aggregations,
-        "default_industry_aggregation": industry_aggregations[0],
+        "default_matname": matnames[0].matname,
+        "agglevels": agglevels,
+        "default_agglevel": agglevels[0].AggLevel,
         "iea_user": iea_user,
         "site_version": settings.SITE_VERSION,  # version of the site to be displayed to users
     }

--- a/Mexer_site/templates/components/visualizer/plotting-menu.html
+++ b/Mexer_site/templates/components/visualizer/plotting-menu.html
@@ -73,10 +73,11 @@
                     >
                         {% for dataset in datasets %}
                         <option
-                            value="{{ dataset }}"
-                            {% if dataset == default_dataset %}selected{%endif%}
+                            value="{{ dataset.Dataset }}"
+                            title="{{ dataset.Description }}"
+                            {% if dataset.Dataset == default_dataset %}selected{%endif%}
                         >
-                            {{ dataset }}
+                            {{ dataset.Dataset }}
                         </option>
                         {% endfor %}
                     </select>
@@ -97,10 +98,10 @@
                     >
                         {% for version in versions %}
                         <option
-                            value="{{ version }}"
-                            {% if version == default_version %}selected{% endif %}
+                            value="{{ version.Version }}"
+                            {% if version.Version == default_version %}selected{% endif %}
                         >
-                            {{ version }}
+                            {{ version.Version }}
                         </option>
                         {% endfor %}
                     </select>
@@ -114,10 +115,10 @@
                     >
                         {% for version in sandbox_versions %}
                         <option
-                            value="{{ version }}"
-                            {% if version == default_sandbox_version %}selected{% endif %}
+                            value="{{ version.Version }}"
+                            {% if version.Version == default_sandbox_version %}selected{% endif %}
                         >
-                            {{ version }}
+                            {{ version.Version }}
                         </option>
                         {% endfor %}
                     </select>
@@ -138,10 +139,11 @@
                     >
                         {% for country in countries %}
                         <option
-                            value="{{ country }}"
-                            {% if country == default_country %}selected{% endif %}
+                            value="{{ country.FullName }}"
+                            title="{{ country.Description }}"
+                            {% if country.FullName == default_country %}selected{% endif %}
                         >
-                            {{ country }}
+                            {{ country.FullName }}
                         </option>
                         {% endfor %}
                     </select>
@@ -167,17 +169,18 @@
                     >
                         <input
                             type="checkbox"
-                            value="{{ method }}"
+                            value="{{ method.Method }}"
                             class="hidden peer"
                             name="method"
-                            {% if method == default_method %}checked{% endif %}
+                            {% if method.Method == default_method %}checked{% endif %}
                         />
                         <span
                             class="w-5 h-5 inline-block border-2 border-gray-300 rounded-md peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
                         ></span>
                         <span
                             class="text-gray-800 peer-checked:text-blue-500 font-medium group-hover:text-blue-400 transition"
-                            >{{ method }}</span
+                            title="{{ method.Description }}"
+                            >{{ method.Method }}</span
                         >
                     </label>
                     {% endfor %}
@@ -196,17 +199,18 @@
                     >
                         <input
                             type="checkbox"
-                            value="{{ energy_type }}"
+                            value="{{ energy_type.FullName }}"
                             class="hidden peer"
                             name="energy_type"
-                            {% if energy_type == default_energy_type %}checked{% endif %}
+                            {% if energy_type.FullName == default_energy_type %}checked{% endif %}
                         />
                         <span
                             class="w-5 h-5 inline-block border-2 border-gray-300 rounded-md peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
                         ></span>
                         <span
                             class="text-gray-800 peer-checked:text-blue-500 font-medium group-hover:text-blue-400 transition"
-                            >{{ energy_type }}</span
+                            title="{{ energy_type.Description }}"
+                            >{{ energy_type.FullName }}</span
                         >
                     </label>
                     {% endfor %}
@@ -220,24 +224,25 @@
                 </div>
                 <div class="mt-2">
                     <div class="flex flex-col space-y-2">
-                        {% for last_stage in last_stages %}
+                        {% for stage in last_stages %}
                         <label
                             class="flex items-center space-x-3 cursor-pointer group"
                         >
                             <input
                                 type="radio"
-                                value="{{ last_stage }}"
+                                value="{{ stage.ECCStage }}"
                                 name="last_stage"
                                 class="hidden peer"
                                 required
-                                {% if last_stage == default_last_stage %}checked{% endif %}
+                                {% if stage.ECCStage == default_last_stage %}checked{% endif %}
                             />
                             <span
                                 class="w-5 h-5 inline-block border-2 border-gray-300 rounded-full peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
                             ></span>
                             <span
                                 class="text-gray-800 peer-checked:text-blue-500 font-medium group-hover:text-blue-400 transition"
-                                >{{ last_stage }}</span
+                                title="{{ stage.Description }}"
+                                >{{ stage.ECCStage }}</span
                             >
                         </label>
                         {% endfor %}
@@ -266,23 +271,24 @@
                     {% field_label "Product Aggregation" "Choose the desired Product Aggregation." %}
                 </div>
                 <div class="mt-2">
-                    {% for product_aggregation in product_aggregations %}
+                    {% for agglevel in agglevels %}
                     <label
                         class="flex items-center space-x-3 cursor-pointer group"
                     >
                         <input
                             type="checkbox"
-                            value="{{ product_aggregation }}"
+                            value="{{ agglevel.AggLevel }}"
                             name="product_aggregation"
                             class="hidden peer"
-                            {% if product_aggregation == default_product_aggregation %}checked{% endif %}
+                            {% if agglevel.AggLevel == default_agglevel %}checked{% endif %}
                         />
                         <span
                             class="w-5 h-5 inline-block border-2 border-gray-300 rounded-md peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
                         ></span>
                         <span
                             class="text-gray-800 peer-checked:text-blue-500 font-medium group-hover:text-blue-400 transition"
-                            >{{ product_aggregation }}</span
+                            title="{{ agglevel.Description }}"
+                            >{{ agglevel.AggLevel }}</span
                         >
                     </label>
                     {% endfor %}
@@ -295,23 +301,25 @@
                     {% field_label "Sector Aggregation" "Choose the desired Sector Aggregation." %}
                 </div>
                 <div class="mt-2">
-                    {% for industry_aggregation in industry_aggregations %}
+                    {% for agglevel in agglevels %}
                     <label
                         class="flex items-center space-x-3 cursor-pointer group"
                     >
                         <input
                             type="checkbox"
-                            value="{{ industry_aggregation }}"
+                            value="{{ agglevel.AggLevel }}"
+                            title="{{ agglevel.Description }}"x
                             name="industry_aggregation"
                             class="hidden peer"
-                            {% if industry_aggregation == default_industry_aggregation %}checked{% endif %}
+                            {% if agglevel.AggLevel == default_agglevel %}checked{% endif %}
                         />
                         <span
                             class="w-5 h-5 inline-block border-2 border-gray-300 rounded-md peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
                         ></span>
                         <span
                             class="text-gray-800 peer-checked:text-blue-500 font-medium group-hover:text-blue-400 transition"
-                            >{{ industry_aggregation }}</span
+                            title="{{ agglevel.Description }}"
+                            >{{ agglevel.AggLevel }}</span
                         >
                     </label>
                     {% endfor %}
@@ -405,18 +413,19 @@
                         >
                             <input
                                 type="radio"
-                                value="{{ grossnet }}"
+                                value="{{ grossnet.GrossNet }}"
                                 name="grossnet"
                                 class="hidden peer"
                                 required
-                                {% if grossnet == default_grossnet %}checked{% endif %}
+                                {% if grossnet.GrossNet == default_grossnet %}checked{% endif %}
                             />
                             <span
                                 class="w-5 h-5 inline-block border-2 border-gray-300 rounded-full peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
                             ></span>
                             <span
                                 class="text-gray-800 peer-checked:text-blue-500 font-medium group-hover:text-blue-400 transition"
-                                >{{ grossnet }}</span
+                                title="{{ grossnet.Description }}"
+                                >{{ grossnet.GrossNet }}</span
                             >
                         </label>
                         {% endfor %}
@@ -588,7 +597,10 @@
                 >
                     <option value="RUVY" selected>RUVY</option>
                     {% for matname in matnames %}
-                    <option value="{{ matname }}">{{ matname }}</option>
+                    <option
+                        value="{{ matname.matname }}"
+                        title="{{ matname.Description }}"
+                    >{{ matname.matname }}</option>
                     {% endfor %}
                 </select>
             </div>

--- a/Mexer_site/templates/components/visualizer/plotting-menu.html
+++ b/Mexer_site/templates/components/visualizer/plotting-menu.html
@@ -271,15 +271,14 @@
                         class="flex items-center space-x-3 cursor-pointer group"
                     >
                         <input
-                            type="radio"
+                            type="checkbox"
                             value="{{ product_aggregation }}"
                             name="product_aggregation"
                             class="hidden peer"
-                            required
                             {% if product_aggregation == default_product_aggregation %}checked{% endif %}
                         />
                         <span
-                            class="w-5 h-5 inline-block border-2 border-gray-300 rounded-full peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
+                            class="w-5 h-5 inline-block border-2 border-gray-300 rounded-md peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
                         ></span>
                         <span
                             class="text-gray-800 peer-checked:text-blue-500 font-medium group-hover:text-blue-400 transition"
@@ -301,15 +300,14 @@
                         class="flex items-center space-x-3 cursor-pointer group"
                     >
                         <input
-                            type="radio"
+                            type="checkbox"
                             value="{{ industry_aggregation }}"
                             name="industry_aggregation"
                             class="hidden peer"
-                            required
                             {% if industry_aggregation == default_industry_aggregation %}checked{% endif %}
                         />
                         <span
-                            class="w-5 h-5 inline-block border-2 border-gray-300 rounded-full peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
+                            class="w-5 h-5 inline-block border-2 border-gray-300 rounded-md peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
                         ></span>
                         <span
                             class="text-gray-800 peer-checked:text-blue-500 font-medium group-hover:text-blue-400 transition"
@@ -327,7 +325,7 @@
             class="w-3/4 bg-gray-100 text-gray-800 p-6 shadow-lg overflow-scroll"
         >
             <h2 class="text-2xl font-bold text-gray-800 mb-4 text-center">
-                Plot
+                Plot & Download
             </h2>
 
             <!-- Visualization selection -->

--- a/Mexer_site/templates/components/visualizer/plotting-menu.html
+++ b/Mexer_site/templates/components/visualizer/plotting-menu.html
@@ -74,13 +74,7 @@
                         {% for dataset in datasets %}
                         <option
                             value="{{ dataset }}"
-                            {%
-                            if
-                            dataset=""
-                            ="default_dataset"
-                            %}selected{%
-                            endif
-                            %}
+                            {% if dataset == default_dataset %}selected{%endif%}
                         >
                             {{ dataset }}
                         </option>
@@ -104,13 +98,7 @@
                         {% for version in versions %}
                         <option
                             value="{{ version }}"
-                            {%
-                            if
-                            version=""
-                            ="default_version"
-                            %}selected{%
-                            endif
-                            %}
+                            {% if version == default_version %}selected{% endif %}
                         >
                             {{ version }}
                         </option>
@@ -127,13 +115,7 @@
                         {% for version in sandbox_versions %}
                         <option
                             value="{{ version }}"
-                            {%
-                            if
-                            version=""
-                            ="default_sandbox_version"
-                            %}selected{%
-                            endif
-                            %}
+                            {% if version == default_sandbox_version %}selected{% endif %}
                         >
                             {{ version }}
                         </option>
@@ -157,13 +139,7 @@
                         {% for country in countries %}
                         <option
                             value="{{ country }}"
-                            {%
-                            if
-                            country=""
-                            ="default_country"
-                            %}selected{%
-                            endif
-                            %}
+                            {% if country == default_country %}selected{% endif %}
                         >
                             {{ country }}
                         </option>
@@ -194,13 +170,7 @@
                             value="{{ method }}"
                             class="hidden peer"
                             name="method"
-                            {%
-                            if
-                            method=""
-                            ="default_method"
-                            %}checked{%
-                            endif
-                            %}
+                            {% if method == default_method %}checked{% endif %}
                         />
                         <span
                             class="w-5 h-5 inline-block border-2 border-gray-300 rounded-md peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
@@ -229,13 +199,7 @@
                             value="{{ energy_type }}"
                             class="hidden peer"
                             name="energy_type"
-                            {%
-                            if
-                            energy_type=""
-                            ="default_energy_type"
-                            %}checked{%
-                            endif
-                            %}
+                            {% if energy_type == default_energy_type %}checked{% endif %}
                         />
                         <span
                             class="w-5 h-5 inline-block border-2 border-gray-300 rounded-md peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
@@ -266,13 +230,7 @@
                                 name="last_stage"
                                 class="hidden peer"
                                 required
-                                {%
-                                if
-                                last_stage=""
-                                ="default_last_stage"
-                                %}checked{%
-                                endif
-                                %}
+                                {% if last_stage == default_last_stage %}checked{% endif %}
                             />
                             <span
                                 class="w-5 h-5 inline-block border-2 border-gray-300 rounded-full peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
@@ -318,13 +276,7 @@
                             name="product_aggregation"
                             class="hidden peer"
                             required
-                            {%
-                            if
-                            product_aggregation=""
-                            ="default_product_aggregation"
-                            %}checked{%
-                            endif
-                            %}
+                            {% if product_aggregation == default_product_aggregation %}checked{% endif %}
                         />
                         <span
                             class="w-5 h-5 inline-block border-2 border-gray-300 rounded-full peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
@@ -354,13 +306,7 @@
                             name="industry_aggregation"
                             class="hidden peer"
                             required
-                            {%
-                            if
-                            industry_aggregation=""
-                            ="default_industry_aggregation"
-                            %}checked{%
-                            endif
-                            %}
+                            {% if industry_aggregation == default_industry_aggregation %}checked{% endif %}
                         />
                         <span
                             class="w-5 h-5 inline-block border-2 border-gray-300 rounded-full peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"
@@ -465,13 +411,7 @@
                                 name="grossnet"
                                 class="hidden peer"
                                 required
-                                {%
-                                if
-                                grossnet=""
-                                ="default_grossnet"
-                                %}checked{%
-                                endif
-                                %}
+                                {% if grossnet == default_grossnet %}checked{% endif %}
                             />
                             <span
                                 class="w-5 h-5 inline-block border-2 border-gray-300 rounded-full peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"

--- a/Mexer_site/utils/data.py
+++ b/Mexer_site/utils/data.py
@@ -196,48 +196,27 @@ def get_excel_from_query(
 def shape_post_request(
     params: QueryDict,
 ) -> tuple[ShapedQuery, str | None, DatabaseTarget]:
-    """Turn a POST request payload into a ready to use query in a dictionary
-
-    Input:
-
-        payload, some dict-like (used with Django HttpRequest POST attributes):
-        the POST payload to shape into a query dictionary
-
-        get_plot_type, bool: whether or not to get and give the plot type in the payload
-
-    Output:
-
-        a dictionary containing all the associations of a query parts and their values
-
-        IF get_plot_type is True:
-
-            2-tuple containing in top-down order
-
-                a string telling the plot type requested
-
-                a dictionary containing all the associations of a query parts and their values
-    """
+    """Turn a POST request payload into a ready to use query in a dictionary"""
 
     # Get rid of security token; it is not part of a query.
     SKIP_PARAMS = ("csrfmiddlewaretoken",)
 
     # Shaped query extracts items from lists.
-    def shaped_value(key: str, value: str | list[object]) -> str | list[str] | None:
+    def shaped_value(key: str, value: list[str]) -> str | list[str] | None:
         if key in SKIP_PARAMS:
             return None
-        if isinstance(value, str):
-            return value
-        if len(value) == 1 and isinstance(value[0], str):
+        if len(value) == 1:
             return value[0]
-        if all(isinstance(item, str) for item in value):
-            return cast(list[str], value)
+        if len(value) > 1:
+            return value
         LOGGER.warning(f"Non-string POST param for key {key}")
 
     shaped_query = {
         key: value
         for key in params
-        if (value := shaped_value(key, params[key])) is not None
+        if (value := shaped_value(key, params.getlist(key))) is not None
     }
+    LOGGER.info(f"Shaped post request {shaped_query}")
     plot_type = str(shaped_query.get("plot_type"))
     db_target = get_database_target(shaped_query)
     return shaped_query, plot_type, db_target
@@ -316,9 +295,19 @@ def translate_query(target: DatabaseTarget, query: ShapedQuery) -> dict[str, Any
     if v := query.get("chopped_var"):
         translated["ChoppedVar"] = translator.index_translate(v)
     if v := query.get("product_aggregation"):
-        translated["ProductAggregation"] = translator.agglevel_translate(v)
+        if isinstance(v, list):
+            translated["ProductAggregation__in"] = [
+                translator.agglevel_translate(agglevel) for agglevel in v
+            ]
+        else:
+            translated["ProductAggregation"] = translator.agglevel_translate(v)
     if v := query.get("industry_aggregation"):
-        translated["IndustryAggregation"] = translator.agglevel_translate(v)
+        if isinstance(v, list):
+            translated["IndustryAggregation__in"] = [
+                translator.agglevel_translate(agglevel) for agglevel in v
+            ]
+        else:
+            translated["IndustryAggregation"] = translator.agglevel_translate(v)
     if v := query.get("grossnet"):
         translated["GrossNet"] = translator.grossnet_translate(v)
     # plot-specific query parts

--- a/Mexer_site/utils/tests/test_data.py
+++ b/Mexer_site/utils/tests/test_data.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.http import QueryDict
 from django.test import TransactionTestCase
 from Mexer.models import PSUT, AggEtaPFU, IEAData
 
@@ -74,12 +75,11 @@ class DataTests(TransactionTestCase):
         self.assertTrue(isinstance(excel_data, bytes))
 
     def test_shape_post_request(self):
-        payload = {
-            "csrfmiddlewaretoken": "dummy_token",
-            "dataset": "IEAEWEB2022",
-            "plot_type": "xy_plot",
-        }
-        shaped_query, plot_type, db_target = shape_post_request(payload)
+        q = QueryDict("", mutable=True)
+        q["csrfmiddlewaretoken"] = "dummy_token"
+        q["dataset"] = "IEAEWEB2022"
+        q["plot_type"] = "xy_plot"
+        shaped_query, plot_type, db_target = shape_post_request(q)
         self.assertNotIn("csrfmiddlewaretoken", shaped_query)
         self.assertEqual(plot_type, "xy_plot")
         self.assertEqual(db_target, ("default", AggEtaPFU))


### PR DESCRIPTION
This pull request adds a number of small features to the visualizer.

1. Every dropdown and checkbox/radio option has a description when hovered over with the mouse cursor. This description comes directly from the database (the `Description` column).
2. Bug fixed in the query shaping backend which prevented multi-select from ever working (only last selected option went through).
3. Aggregation fields in the query are now multi-select.

Note: For now, the visualizer view no longer uses the _translator_, which caches the enumerated attribute tables to build the view quickly. This is because the translator did not store the descriptions necessary, so instead, the visualizer hits the attribute tables every time the page is loaded. The difference in load time for the webpage was **unnoticeable** since these tables are so small, but an in-progress rewrite of the translator (which removes hardcoded information, among other improvements) will include the descriptions so we can use caching again.

Examples of tooltips (uses plain HTML):

<img width="859" height="175" alt="image" src="https://github.com/user-attachments/assets/64092e02-4f6a-4f59-ac42-1d16ddd1dd92" />

<img width="734" height="204" alt="image" src="https://github.com/user-attachments/assets/985366dc-b334-4c3b-a726-5a2381acf6d8" />

Closes #209.

Closes #210.
