### PR TITLE
Use data-driven field descriptions

### DIFF
--- a/Mexer_site/Mexer/views/visualizer.py
+++ b/Mexer_site/Mexer/views/visualizer.py
@@ -101,11 +101,23 @@ def visualizer(request):
     matnames = lookups.get_objects(model=models.Matname)
     matnames.sort(key=lambda m: m.full_name)
 
-    # TODO: Use AttributeTables description column
+    # Use AttributeTables description column
     # for field-level tooltips.
+
+    descriptions = {
+        "dataset": lookups[models.Dataset].attribute.description,
+        "version": lookups[models.Version].attribute.description,
+        "country": lookups[models.Country].attribute.description,
+        "method": lookups[models.Method].attribute.description,
+        "energy_type": lookups[models.EnergyType].attribute.description,
+        "ecc_stage": lookups[models.ECCStage].attribute.description,
+        "agg_level": lookups[models.AggLevel].attribute.description,
+        "gross_net": lookups[models.GrossNet].attribute.description,
+    }
 
     # Prepare the context dictionary for the template
     context = {
+        "descriptions": descriptions,
         "SANDBOX_PREFIX": settings.SANDBOX_PREFIX,
         "datasets": datasets,
         "sandbox_datasets": sandbox_datasets,

--- a/Mexer_site/Mexer/views/visualizer.py
+++ b/Mexer_site/Mexer/views/visualizer.py
@@ -105,14 +105,30 @@ def visualizer(request):
     # for field-level tooltips.
 
     descriptions = {
-        "dataset": lookups[models.Dataset].attribute.description,
-        "version": lookups[models.Version].attribute.description,
-        "country": lookups[models.Country].attribute.description,
-        "method": lookups[models.Method].attribute.description,
-        "energy_type": lookups[models.EnergyType].attribute.description,
-        "ecc_stage": lookups[models.ECCStage].attribute.description,
-        "agg_level": lookups[models.AggLevel].attribute.description,
-        "gross_net": lookups[models.GrossNet].attribute.description,
+        "dataset": models.AttributeTables.objects.filter(table_name="Dataset")
+        .get()
+        .table_description,
+        "version": models.AttributeTables.objects.filter(table_name="Version")
+        .get()
+        .table_description,
+        "country": models.AttributeTables.objects.filter(table_name="Country")
+        .get()
+        .table_description,
+        "method": models.AttributeTables.objects.filter(table_name="Method")
+        .get()
+        .table_description,
+        "energy_type": models.AttributeTables.objects.filter(table_name="EnergyType")
+        .get()
+        .table_description,
+        "ecc_stage": models.AttributeTables.objects.filter(table_name="ECCStage")
+        .get()
+        .table_description,
+        "agg_level": models.AttributeTables.objects.filter(table_name="AggLevel")
+        .get()
+        .table_description,
+        "gross_net": models.AttributeTables.objects.filter(table_name="GrossNet")
+        .get()
+        .table_description,
     }
 
     # Prepare the context dictionary for the template

--- a/Mexer_site/static/css/visualizer.css
+++ b/Mexer_site/static/css/visualizer.css
@@ -44,14 +44,14 @@ html {
     color: whitesmoke;
     background-color: #393e46;
     box-shadow: #191b1e 0px 0px 50px;
-    overflow: hidden;
+    /*overflow: hidden;*/
     position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
 }
 
-#plot-section>div {
+#plot-section > div {
     width: 100%;
     height: 100%;
 }
@@ -72,7 +72,6 @@ html {
 #plot-with-extra {
     position: relative;
     height: 100%;
-
 }
 
 #spinner-container {
@@ -150,15 +149,14 @@ html {
 }
 
 .main-button {
-    background-color: #00ADB5;
+    background-color: #00adb5;
     border-radius: 10px;
     border: 0;
     height: 40px;
     width: 150px;
     font-size: 20px;
     color: #191b1e;
-    margin-right: 10px; 
-    
+    margin-right: 10px;
 }
 
 .main-button:hover {
@@ -187,7 +185,7 @@ html {
 /* outer ring + ring setups */
 .loader::after,
 .loader::before {
-    content: '';
+    content: "";
     box-sizing: border-box;
     position: absolute;
     left: 0;
@@ -312,7 +310,7 @@ html {
 .history-toggle-btn {
     position: absolute;
     top: 13vh;
-    left: 10px; 
+    left: 10px;
     z-index: 1001;
     background: #333;
     color: white;
@@ -326,11 +324,11 @@ html {
 .sidebar {
     position: absolute;
     top: 11vh;
-    left: -250px; 
+    left: -250px;
     width: 250px;
     /* height: 100%; */
     background-color: #191b1e;
-    transition: left 0.3s ease; 
+    transition: left 0.3s ease;
     z-index: 1000;
     padding: 20px;
     box-sizing: border-box;
@@ -347,11 +345,11 @@ html {
 }
 
 .sidebar.open {
-    left: 0; 
+    left: 0;
 }
 
 .history-toggle-btn.open {
-    left: 270px; 
+    left: 270px;
 }
 
 .history-button {
@@ -387,8 +385,7 @@ html {
     position: relative;
 }
 
-
-.arrow-section{
+.arrow-section {
     position: absolute;
     top: 20%;
     left: 80%;
@@ -446,7 +443,7 @@ html {
 
 #download-options-button {
     display: inline-block;
-    background-color: #00ADB5;
+    background-color: #00adb5;
     border-radius: 10px;
     border: 0;
     height: 40px;
@@ -469,7 +466,7 @@ html {
     position: relative;
     background-color: #191b1e;
     border-radius: 10px;
-    box-shadow: 0px 0px 10px #00ADB5;
+    box-shadow: 0px 0px 10px #00adb5;
     padding: 10px;
     position: absolute;
     top: 50px;
@@ -489,7 +486,7 @@ html {
 }
 
 #download-options button {
-    background-color: #00ADB5;
+    background-color: #00adb5;
     border-radius: 10px;
     border: 0;
     height: 40px;

--- a/Mexer_site/templates/components/visualizer/plotting-menu.html
+++ b/Mexer_site/templates/components/visualizer/plotting-menu.html
@@ -62,7 +62,7 @@
             <!-- Dataset selection -->
             <div>
                 <div class="flex items-center space-x-2">
-                    {% field_label "From dataset" "Choose the dataset of interest." link_url="/data-info" link_text="Read more." %}
+                    {% field_label "From dataset" descriptions.dataset link_url="/data-info" link_text="Read more." %}
                 </div>
                 <div class="mt-2">
                     <select
@@ -95,7 +95,7 @@
             <!-- Version selection -->
             <div>
                 <div class="flex items-center space-x-2">
-                    {% field_label "Version" "Choose the version of interest." %}
+                    {% field_label "Version" descriptions.version %}
                 </div>
                 <div class="mt-2">
                     <select
@@ -136,7 +136,7 @@
             <!-- Country selection -->
             <div>
                 <div class="flex items-center space-x-2">
-                    {% field_label "Region(s)" "Choose the region(s) of interest. Click \"Add Country\" to enable additional countries." %}
+                    {% field_label "Region(s)" descriptions.country %}
                 </div>
                 <div class="mt-2">
                     <select
@@ -168,7 +168,7 @@
             <!-- Method selection -->
             <div>
                 <div class="flex items-center space-x-2">
-                    {% field_label "Method" "Choose the method of accounting for the primary equivalent of renewable electricity." %}
+                    {% field_label "Method" descriptions.method %}
                 </div>
                 <div class="mt-2">
                     {% for method in methods %}
@@ -198,7 +198,7 @@
             <!-- Energy Type selection -->
             <div>
                 <div class="flex items-center space-x-2">
-                    {% field_label "Energy Type" "Choose one of energy or exergy. Energy is a heat quantification of energy. Exergy is a work quantification of energy." %}
+                    {% field_label "Energy Type" descriptions.energy_type %}
                 </div>
                 <div class="mt-2">
                     {% for energy_type in energy_types %}
@@ -228,7 +228,7 @@
             <!-- Last Stage selection -->
             <div>
                 <div class="flex items-center space-x-2">
-                    {% field_label "Last Stage" "Choose the last stage of the energy conversion chain, either final or useful." %}
+                    {% field_label "Last Stage" descriptions.ecc_stage %}
                 </div>
                 <div class="mt-2">
                     <div class="flex flex-col space-y-2">
@@ -268,7 +268,7 @@
                         class="hidden peer"
                         checked
                     />
-                    {% field_label "Include NEU" "Choose whether to include non-energy uses (NEU) of energy carriers in final demand." %}
+                    {% field_label "Include NEU" "Whether to include non-energy uses (NEU) of energy carriers in final demand." %}
                     <span class="w-5 h-5 inline-block border-2 border-gray-300 rounded-md peer-checked:bg-blue-500 peer-checked:border-blue-500 transition group-hover:scale-110"></span>
                 </label>
             </div>
@@ -276,7 +276,7 @@
             <!-- Product Aggregation selection -->
             <div>
                 <div class="flex items-center space-x-2">
-                    {% field_label "Product Aggregation" "Choose the desired Product Aggregation." %}
+                    {% field_label "Product Aggregation" descriptions.agg_level %}
                 </div>
                 <div class="mt-2">
                     {% for agg_level in agg_levels %}
@@ -306,7 +306,7 @@
             <!-- Sector Aggregation selection -->
             <div>
                 <div class="flex items-center space-x-2">
-                    {% field_label "Sector Aggregation" "Choose the desired Sector Aggregation." %}
+                    {% field_label "Sector Aggregation" descriptions.agg_level %}
                 </div>
                 <div class="mt-2">
                     {% for agg_level in agg_levels %}
@@ -410,7 +410,7 @@
             <!-- GrossNet selection -->
             <div class="query-choice">
                 <div class="flex items-center space-x-2">
-                    {% field_label "Gross/Net" "Gross/Net" %}
+                    {% field_label "Gross/Net" descriptions.gross_net %}
                 </div>
                 <div class="mt-2">
                     <div class="flex flex-col space-y-2" id="gross_net_radio">

--- a/Mexer_site/templates/partials/field_label.html
+++ b/Mexer_site/templates/partials/field_label.html
@@ -2,19 +2,30 @@
     <button
         type="button"
         class="info-toggle text-blue-500 focus:outline-none"
-        title="info"
-        onclick="this.nextElementSibling.classList.toggle('hidden')"
+        title="Click for field details"
+        onclick="
+        const tip = this.nextElementSibling;
+        const hidden = tip.classList.toggle('hidden');
+        if (!hidden) {
+            const btnRect = this.getBoundingClientRect();
+            tip.style.left = btnRect.left + 'px';
+            tip.style.width = '16rem';
+            const spaceAbove = btnRect.top;
+            if (spaceAbove > 100) {
+                tip.style.top = '';
+                tip.style.bottom = (window.innerHeight - btnRect.top + 4) + 'px';
+            } else {
+                tip.style.bottom = '';
+                tip.style.top = (btnRect.bottom + 4) + 'px';
+            }
+        }
+        "
     >
         &#9432;
     </button>
-    <div
-        class="hidden absolute bottom-full left-0 mb-1 w-64 bg-gray-800 text-white text-sm rounded-md p-2 shadow-lg z-20"
-    >
-        {{ tooltip }} {% if link_url %}
-        <a href="{{ link_url }}" class="text-blue-400 underline"
-            >{{ link_text }}</a
-        >
-        {% endif %}
+    <div class="hidden fixed w-64 bg-gray-800 text-white text-sm rounded-md p-2 shadow-lg z-50">
+        {{ tooltip }}
+        {% if link_url %}<a href="{{ link_url }}" class="text-blue-400 underline">{{ link_text }}</a>{% endif %}
     </div>
     <span class="font-semibold">{{ label }}</span>
 </div>


### PR DESCRIPTION
Info tooltips for the fields in the visualizer are now taken from the AttributeTables database table.

@MatthewHeun: These descriptions are very technical and pertain to the structure of the database, when ideally they should be user-facing text describing the purpose of a field in data querying.

For example, the current Method table description is as follows:

> The Method table provides integer encodings and descriptions for ways of accounting the primary equivalent of renewable electricity.

A more user-focused description could simply be something like:

>The means of accounting the primary equivalent of renewable electricity.