### PR TITLE
Making subsets of IEA data freely available

### DIFF
--- a/Mexer_site/Mexer/views/visualizer.py
+++ b/Mexer_site/Mexer/views/visualizer.py
@@ -12,11 +12,12 @@
 #####################
 import json
 import time
+from copy import deepcopy
 
 from altair.utils.data import MaxRowsError  # for catching with matrices are too big
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from Mexer import models
@@ -335,6 +336,30 @@ def get_plot(request: HttpRequest):
     response.set_cookie("user_history", serialized_data.hex(), max_age=7 * 24 * 60 * 60)
 
     return response
+
+
+def check_data_iea(request: HttpRequest):
+    if request.method != "POST":
+        return HttpResponse(status=405)
+
+    LOGGER.info(f"Raw data: {request.POST}")
+
+    data_format = request.POST.get("return_data_type")
+    if data_format is None:
+        return HttpResponse("Data format unspecified", status=400)
+
+    query = shape_post_request(request.POST)[0]
+    original_query = deepcopy(query)
+    valid = iea_valid(request.user, query)
+
+    # Return modified query.
+    return JsonResponse(
+        {
+            "original": original_query,
+            "modified": query,
+            "valid": valid,
+        }
+    )
 
 
 @time_view

--- a/Mexer_site/utils/iea_available.py
+++ b/Mexer_site/utils/iea_available.py
@@ -20,6 +20,9 @@ def can_all_users_access(query: ShapedQuery) -> bool:
 
 
 # See example access conditions below.
+#
+# Names of fields (query keys) are provided in the plotting-menu.html file.
+# Search for name="" attributes on input elements.
 
 
 def example_can_all_users_access(query: ShapedQuery) -> bool:
@@ -33,12 +36,14 @@ def example_can_all_users_access(query: ShapedQuery) -> bool:
     # If country is omitted or UK is present,
     # restrict to just UK.
     if "country" not in query or "United Kingdom" in query["country"]:
-        query["country__in"] = ["United Kingdom"]
+        query["country"] = "United Kingdom"
     else:
         # Invalid country specified; no data.
         return False
 
     # Also restrict year range.
+    # "year" and "to_year" are the keys that
+    # make up the year range in the query.
     if "year" in query:
         from_year = int(query["year"])
         if from_year < 2016:
@@ -46,6 +51,21 @@ def example_can_all_users_access(query: ShapedQuery) -> bool:
     if "to_year" in query:
         to_year = int(query["to_year"])
         if to_year > 2019:
-            query["year"] = "2019"
+            query["to_year"] = "2019"
 
     return True
+
+
+query = {
+    "country": ["Spain", "United Kingdom"],
+    "year": "2014",
+    "to_year": "2020",
+}
+
+# Output
+
+query = {
+    "country": ["United Kingdom"],
+    "year": "2016",
+    "to_year": "2019",
+}

--- a/Mexer_site/utils/iea_available.py
+++ b/Mexer_site/utils/iea_available.py
@@ -1,0 +1,58 @@
+from collections.abc import MutableMapping
+
+type ShapedQuery = MutableMapping[str, str | list[str]]
+
+
+def can_all_users_access(query: ShapedQuery) -> bool:
+    """This function determines whether a request from a non-IEA-authorized
+    user can access IEA data. The conditions in this function's code should
+    describe the IEA data which is available to all users.
+
+    This function may:
+      - Allow the request through, returning True, which means "allow".
+      - Modify the disallowed query to a narrower allowed query,
+        returning True, which means "allow".
+      - Reject the query, returning False, which means "disallow"."""
+
+    # Currently, no IEA data is known to be available
+    # to all users.
+    return False
+
+
+# See example access conditions below.
+
+
+def example_can_all_users_access(query: ShapedQuery) -> bool:
+    """This function makes IEA data from the UK from years 2016-2019
+    available to anybody."""
+
+    # Only queries in the UK region are allowed.
+    # TODO: region aggregation info could allow
+    # narrowing to the UK.
+    valid_country = False
+
+    # country__in is the Django query keyword for lists of selected options.
+    # This constrains the country to just the UK.
+    if "country__in" in query and "United Kingdom" in query["country__in"]:
+        valid_country = True
+        query["country__in"] = ["United Kingdom"]
+
+    if "country" in query and "United Kingdom" == query["country"]:
+        valid_country = True
+
+    # Also, only queries from the years 2016-2019 are allowed.
+    valid_year = False
+
+    if "year" in query and query["year"] in ("2016", "2017", "2018", "2019"):
+        valid_year = True
+
+    # year__gte and year__lte are the Django query keywords for ranges of numbers.
+    if "year__gte" in query and "year__lte" in query:
+        if int(query["year__gte"]) < 2016:
+            query["year__gte"] = "2016"  # Query values must be strings.
+        if int(query["year__lte"]) > 2019:
+            query["year__lte"] = "2019"
+        valid_year = True
+
+    valid = valid_country and valid_year
+    return valid

--- a/Mexer_site/utils/iea_available.py
+++ b/Mexer_site/utils/iea_available.py
@@ -29,30 +29,23 @@ def example_can_all_users_access(query: ShapedQuery) -> bool:
     # Only queries in the UK region are allowed.
     # TODO: region aggregation info could allow
     # narrowing to the UK.
-    valid_country = False
 
-    # country__in is the Django query keyword for lists of selected options.
-    # This constrains the country to just the UK.
-    if "country__in" in query and "United Kingdom" in query["country__in"]:
-        valid_country = True
+    # If country is omitted or UK is present,
+    # restrict to just UK.
+    if "country" not in query or "United Kingdom" in query["country"]:
         query["country__in"] = ["United Kingdom"]
+    else:
+        # Invalid country specified; no data.
+        return False
 
-    if "country" in query and "United Kingdom" == query["country"]:
-        valid_country = True
+    # Also restrict year range.
+    if "year" in query:
+        from_year = int(query["year"])
+        if from_year < 2016:
+            query["year"] = "2016"
+    if "to_year" in query:
+        to_year = int(query["to_year"])
+        if to_year > 2019:
+            query["year"] = "2019"
 
-    # Also, only queries from the years 2016-2019 are allowed.
-    valid_year = False
-
-    if "year" in query and query["year"] in ("2016", "2017", "2018", "2019"):
-        valid_year = True
-
-    # year__gte and year__lte are the Django query keywords for ranges of numbers.
-    if "year__gte" in query and "year__lte" in query:
-        if int(query["year__gte"]) < 2016:
-            query["year__gte"] = "2016"  # Query values must be strings.
-        if int(query["year__lte"]) > 2019:
-            query["year__lte"] = "2019"
-        valid_year = True
-
-    valid = valid_country and valid_year
-    return valid
+    return True

--- a/Mexer_site/utils/misc.py
+++ b/Mexer_site/utils/misc.py
@@ -13,7 +13,7 @@
 #####################
 
 import sys
-from collections.abc import Mapping
+from collections.abc import MutableMapping
 from os import devnull
 from time import time
 from uuid import uuid4
@@ -24,7 +24,9 @@ from django.contrib.auth.models import AnonymousUser, User
 from Mexer.forms import SignupForm
 from Mexer.models import EmailAuthCode, EvizUser, PassResetCode
 
-type ShapedQuery = Mapping[str, str | list[str]]
+from .iea_available import can_all_users_access
+
+type ShapedQuery = MutableMapping[str, str | list[str]]
 
 
 def time_view(v):
@@ -141,11 +143,17 @@ def iea_valid(user: AbstractBaseUser | AnonymousUser, query: ShapedQuery) -> boo
         return True
 
     # User must be authorized for proprietary data.
-    return (
+    is_iea_user = (
         isinstance(user, User)
         and user.is_authenticated
         and user.has_perm("eviz.get_iea")
     )
+    if is_iea_user:
+        return True
+
+    # Query forms a superset of freely available IEA data.
+    free_data = can_all_users_access(query)
+    return free_data
 
 
 def get_plot_title(query: ShapedQuery, exclude: list[str] | None = None) -> str:

--- a/Mexer_site/utils/tests/test_free_iea.py
+++ b/Mexer_site/utils/tests/test_free_iea.py
@@ -1,0 +1,25 @@
+from django.contrib.auth.models import AnonymousUser
+from django.test import TransactionTestCase
+
+from ..iea_available import can_all_users_access
+from ..misc import ShapedQuery, iea_valid
+
+
+class FreeIEATests(TransactionTestCase):
+    def reject_all_iea(self):
+        free_data = can_all_users_access({})
+        self.assertFalse(free_data)
+
+    def non_iea_exempt(self):
+        query: ShapedQuery = {"dataset": "CL-PFU MW"}
+
+        # Technically, a free data check will fail.
+        # The free data check assumes we've determined it's an IEA query.
+        free_data = can_all_users_access(query)
+        self.assertFalse(free_data)
+
+        # But the query is still valid for any user,
+        # because the data is not IEA.
+        user = AnonymousUser()
+        can_access = iea_valid(user, query)
+        self.assertTrue(can_access)


### PR DESCRIPTION
This PR lays the groundwork for making a subset of IEA data freely available. When the parameters for free IEA data change, the code must be changed and the app redeployed. Using your code editor, search for a file with the name `iea_available.py`. In it, the `can_all_users_access` function takes a shaped query as an argument and returns a True/False value, where True means the user can access the data. The `can_all_users_access` function may also modify the query to narrow it to what is freely available from the IEA.

A query object is a dictionary that has query parameters as keys (e.g. "country", "year", and "to_year") and options as values. The values may be a string (for a single selection) or a list of string (for multiple selections). Note that even for parameters like "year", the values are strings.

Currently, the function just returns False.